### PR TITLE
we need to send info about the browser

### DIFF
--- a/src/kite/kite.coffee
+++ b/src/kite/kite.coffee
@@ -80,6 +80,14 @@ module.exports = class Kite extends EventEmitter
       responseCallback  : (response) ->
         { withArgs:[{ error: err, result }]} = response
         callback err, result
+      kite             :
+        username       : "#{KD.nick()}"
+        environment    : "#{KD.config.environment}"
+        name           : "browser"
+        version        : "1.0.#{KD.config.version}"
+        region         : "browser"
+        hostname       : "browser"
+        id             : uniqueID
 
     # by default, remove this callback after it is called once.
     callback.times ?= 1


### PR DESCRIPTION
Because it is also a kite. That's why the math kite couldn't identify the connected client today and printed "///////" instead "/chris/prod/browser/...".

For environment and region fields; maybe we can have a initializer method that sets those fields globally.
