### PR TITLE
Convert commonjs requires to es6 imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,21 +17,6 @@
     "space-before-function-paren": [
       "error",
       "never"
-    ],
-    "key-spacing": [
-      "error",
-      {
-        "multiLine": {
-          "beforeColon": false,
-          "afterColon": true
-        },
-        "align": {
-          "beforeColon": false,
-          "afterColon": true,
-          "on": "colon",
-          "mode": "strict"
-        }
-      }
     ]
   }
 }

--- a/src/constants.test.js
+++ b/src/constants.test.js
@@ -1,4 +1,5 @@
 import expect from 'expect'
+import pkg from '../package.json'
 import * as constants from './constants'
 
 describe('constants', () =>
@@ -42,5 +43,5 @@ describe('constants', () =>
     expect(constants.DebugLevel.CRITICAL).toBe(0)
     expect(constants.DebugLevel.DEBUG).toBe(5)
 
-    expect(constants.Version).toBe(require('../package.json').version)
+    expect(constants.Version).toBe(pkg.version)
   }))

--- a/src/constants.test.js
+++ b/src/constants.test.js
@@ -1,5 +1,5 @@
-const expect = require('expect')
-const constants = require('./constants')
+import expect from 'expect'
+import * as constants from './constants'
 
 describe('constants', () =>
   it('should expose required constants', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,9 @@
-export const Kite = require('./kite')
-export const Kontrol = require('./kontrol')
-export const KiteServer = require('./server')
+import Kite from './kite'
+import Kontrol from './kontrol'
+import KiteServer from './server'
+
+export default {
+  Kite,
+  Kontrol,
+  KiteServer,
+}

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,5 @@
-const expect = require('expect')
-const kite = require('../src')
+import expect from 'expect'
+import kite from '../src'
 
 describe('kite.js', () =>
   it('should provide Kontrol, Kite and KiteServer', () => {

--- a/src/kite/auth.js
+++ b/src/kite/auth.js
@@ -1,6 +1,6 @@
-const Promise = require('bluebird')
-const handleToken = require('./token')
-const { AuthType, WhiteList } = require('../constants')
+import Promise from 'bluebird'
+import handleToken from './token'
+import { AuthType, WhiteList } from '../constants'
 
 export default Promise.method((kite, method, auth, kiteKey) => {
   if (auth == null) {

--- a/src/kite/backoff.js
+++ b/src/kite/backoff.js
@@ -1,27 +1,21 @@
-const Timeout = require('./timeout')
-const {
-  Backoff: {
-    MAX_DELAY,
-    MAX_RECONNECT_ATTEMPTS,
-    MULTIPLY_FACTOR,
-    INITIAL_DELAY,
-  },
-  Event,
-} = require('../constants')
+import Timeout from './timeout'
+import { Backoff, Event } from '../constants'
 
 export default function(options = {}) {
   const { backoff = {} } = options
   let totalReconnectAttempts = 0
   const initalDelayMs = backoff.initialDelayMs != null
     ? backoff.initialDelayMs
-    : INITIAL_DELAY
+    : Backoff.INITIAL_DELAY
   const multiplyFactor = backoff.multiplyFactor != null
     ? backoff.multiplyFactor
-    : MULTIPLY_FACTOR
-  const maxDelayMs = backoff.maxDelayMs != null ? backoff.maxDelayMs : MAX_DELAY
+    : Backoff.MULTIPLY_FACTOR
+  const maxDelayMs = backoff.maxDelayMs != null
+    ? backoff.maxDelayMs
+    : Backoff.MAX_DELAY
   const maxReconnectAttempts = backoff.maxReconnectAttempts != null
     ? backoff.maxReconnectAttempts
-    : MAX_RECONNECT_ATTEMPTS
+    : Backoff.MAX_RECONNECT_ATTEMPTS
 
   this.clearBackoffTimeout = () => (totalReconnectAttempts = 0)
 

--- a/src/kite/base.js
+++ b/src/kite/base.js
@@ -1,23 +1,16 @@
-const dnode = require('dnode-protocol')
-const WebSocket = require('ws')
-const atob = require('atob')
-const uuid = require('uuid')
-const Emitter = require('./emitter')
-const now = require('./now')
-const backoff = require('./backoff')
-const wrap = require('./wrap')
-const handleIncomingMessage = require('./handleIncomingMessage')
-const enableLogging = require('./enableLogging')
-const Timeout = require('./timeout')
-const KiteError = require('./error')
-
-const {
-  Event,
-  AuthType,
-  Defaults,
-  TimerHandles,
-  State: { NOTREADY, READY, CLOSED, CONNECTING },
-} = require('../constants')
+import dnode from 'dnode-protocol'
+import WebSocket from 'ws'
+import atob from 'atob'
+import uuid from 'uuid'
+import Emitter from './emitter'
+import now from './now'
+import backoff from './backoff'
+import wrap from './wrap'
+import handleIncomingMessage from './handleIncomingMessage'
+import enableLogging from './enableLogging'
+import Timeout from './timeout'
+import KiteError from './error'
+import { Event, AuthType, Defaults, TimerHandles, State } from '../constants'
 
 function __guard__(value, transform) {
   return typeof value !== 'undefined' && value !== null
@@ -46,7 +39,7 @@ class Kite extends Emitter {
     // refresh expired tokens
     this.expireTokenOnExpiry()
 
-    this.readyState = NOTREADY
+    this.readyState = State.NOTREADY
 
     if (this.options.autoReconnect) {
       this.initBackoff()
@@ -78,10 +71,10 @@ class Kite extends Emitter {
   }
 
   connect() {
-    if ([CONNECTING, READY].includes(this.readyState)) {
+    if ([State.CONNECTING, State.READY].includes(this.readyState)) {
       return
     }
-    this.readyState = CONNECTING
+    this.readyState = State.CONNECTING
     const { url, transportClass, transportOptions } = this.options
     const Konstructor = transportClass != null
       ? transportClass
@@ -116,7 +109,7 @@ class Kite extends Emitter {
   }
 
   onOpen() {
-    this.readyState = READY
+    this.readyState = State.READY
     // FIXME: the following is ridiculous.
     this.emit(Event.notice, `Connected to Kite: ${this.options.url}`)
     if (typeof this.clearBackoffTimeout === 'function') {
@@ -126,7 +119,7 @@ class Kite extends Emitter {
   }
 
   onClose(event) {
-    this.readyState = CLOSED
+    this.readyState = State.CLOSED
     this.emit(Event.close, event)
 
     let dcInfo = `${this.options.url}: disconnected`
@@ -246,7 +239,7 @@ class Kite extends Emitter {
   }
 
   ready(callback) {
-    if (this.readyState === READY) {
+    if (this.readyState === State.READY) {
       process.nextTick(callback)
     } else {
       this.once(Event.open, callback)

--- a/src/kite/base.test.js
+++ b/src/kite/base.test.js
@@ -1,6 +1,6 @@
-const expect = require('expect')
-const Kite = require('./base')
-const { Defaults } = require('../constants')
+import expect from 'expect'
+import Kite from './base'
+import { Defaults } from '../constants'
 
 describe('Kite', () => {
   describe('getKiteInfo', () =>

--- a/src/kite/claims.js
+++ b/src/kite/claims.js
@@ -1,5 +1,5 @@
-const atob = require('atob')
-const parse = require('try-json-parse')
+import atob from 'atob'
+import parse from 'try-json-parse'
 
 export default kiteKey => {
   const kontrolClaimsA = kiteKey.split('.')[1]

--- a/src/kite/emitter.js
+++ b/src/kite/emitter.js
@@ -1,5 +1,5 @@
-const { EventEmitter } = require('events')
-const define = require('./define')
+import { EventEmitter } from 'events'
+import define from './define'
 
 export default class Emitter extends EventEmitter {
   bound(method) {

--- a/src/kite/enableLogging.js
+++ b/src/kite/enableLogging.js
@@ -1,37 +1,34 @@
-const {
-  Event,
-  DebugLevel: { CRITICAL, ERROR, WARNING, NOTICE, INFO, DEBUG },
-} = require('../constants')
+import { Event, DebugLevel } from '../constants'
 
 const error = (...args) => console.error(...args)
 const warn = (...args) => console.warn(...args)
 const info = (...args) => console.info(...args)
 
-export default (name = 'kite', emitter, logLevel = INFO) => {
+export default (name = 'kite', emitter, logLevel = DebugLevel.INFO) => {
   const createLogger = (category, fn) => (...messages) =>
     fn(`[${name}] ${category}\t`, ...messages)
 
-  if (CRITICAL <= logLevel) {
+  if (DebugLevel.CRITICAL <= logLevel) {
     emitter.on(Event.critical, createLogger('CRITICAL', error))
   }
 
-  if (ERROR <= logLevel) {
+  if (DebugLevel.ERROR <= logLevel) {
     emitter.on(Event.error, createLogger('ERROR', error))
   }
 
-  if (WARNING <= logLevel) {
+  if (DebugLevel.WARNING <= logLevel) {
     emitter.on(Event.warn, createLogger('WARN', warn))
   }
 
-  if (NOTICE <= logLevel) {
+  if (DebugLevel.NOTICE <= logLevel) {
     emitter.on(Event.notice, createLogger('NOTICE', info))
   }
 
-  if (INFO <= logLevel) {
+  if (DebugLevel.INFO <= logLevel) {
     emitter.on(Event.info, createLogger('INFO', info))
   }
 
-  if (DEBUG <= logLevel) {
+  if (DebugLevel.DEBUG <= logLevel) {
     return emitter.on(Event.debug, createLogger('DEBUG', info))
   }
 }

--- a/src/kite/error.test.js
+++ b/src/kite/error.test.js
@@ -1,5 +1,5 @@
-const expect = require('expect')
-const KiteError = require('./error')
+import expect from 'expect'
+import KiteError from './error'
 
 describe('KiteError', () =>
   it('should provide a generic Error object', () => {

--- a/src/kite/handleIncomingMessage.js
+++ b/src/kite/handleIncomingMessage.js
@@ -1,7 +1,7 @@
-const parse = require('try-json-parse')
-const handleAuth = require('./auth')
-const KiteError = require('./error')
-const { Event } = require('../constants')
+import parse from 'try-json-parse'
+import handleAuth from './auth'
+import KiteError from './error'
+import { Event } from '../constants'
 
 const mungeCallbacks = (callbacks, n) => {
   // FIXME: this is an ugly hack; there must be a better way to implement it:

--- a/src/kite/index.js
+++ b/src/kite/index.js
@@ -1,5 +1,5 @@
-const BaseKite = require('./base')
-const Promise = require('bluebird')
+import BaseKite from './base'
+import Promise from 'bluebird'
 
 class Kite extends BaseKite {
   tell(method, ...params) {

--- a/src/kite/interval.js
+++ b/src/kite/interval.js
@@ -1,4 +1,4 @@
-const Delayed = require('./delayed')
+import Delayed from './delayed'
 
 export default class Interval extends Delayed {
   begin() {

--- a/src/kite/timeout.js
+++ b/src/kite/timeout.js
@@ -1,4 +1,4 @@
-const Delayed = require('./delayed')
+import Delayed from './delayed'
 
 export default class Timeout extends Delayed {
   begin() {

--- a/src/kite/token.js
+++ b/src/kite/token.js
@@ -1,7 +1,7 @@
-const jwt = require('jwt-simple')
-const atob = require('atob')
-const parse = require('try-json-parse')
-const getKontrolClaims = require('./claims')
+import jwt from 'jwt-simple'
+import atob from 'atob'
+import parse from 'try-json-parse'
+import getKontrolClaims from './claims'
 
 export default (tokenString, kiteKey) => {
   const [headersA] = tokenString.split('.')

--- a/src/kite/wrap.js
+++ b/src/kite/wrap.js
@@ -1,4 +1,4 @@
-const Interval = require('./interval')
+import Interval from './interval'
 
 export default function(userlandApi = {}) {
   const api = ['error', 'info', 'log', 'warn'].reduce((api, method) => {

--- a/src/kontrol/base.js
+++ b/src/kontrol/base.js
@@ -1,9 +1,8 @@
-const Emitter = require('events').EventEmitter
-const Kite = require('../kite/base')
-const KiteError = require('../kite/error')
-const getPath = require('./getpath')
-
-const { Event, Defaults, KontrolActions } = require('../constants')
+import { EventEmitter as Emitter } from 'events'
+import Kite from '../kite/base'
+import KiteError from '../kite/error'
+import getPath from './getpath'
+import { Event, Defaults, KontrolActions } from '../constants'
 
 class Kontrol extends Emitter {
   constructor(options) {

--- a/src/kontrol/index.js
+++ b/src/kontrol/index.js
@@ -1,5 +1,6 @@
 import BaseKontrol from './base'
 import Promise from 'bluebird'
+import Kite from '../kite'
 
 const methods = [
   'fetchKites',
@@ -11,9 +12,10 @@ const methods = [
 
 class Kontrol extends BaseKontrol {}
 
-Kontrol.prototype.Kite = require('../kite')
+Kontrol.prototype.Kite = Kite
 
-for (var method of methods)
+for (var method of methods) {
   Kontrol.prototype[method] = Promise.promisify(BaseKontrol.prototype[method])
+}
 
 export default Kontrol

--- a/src/kontrol/index.js
+++ b/src/kontrol/index.js
@@ -1,5 +1,5 @@
-const BaseKontrol = require('./base')
-const Promise = require('bluebird')
+import BaseKontrol from './base'
+import Promise from 'bluebird'
 
 const methods = [
   'fetchKites',

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,19 +1,16 @@
-const Promise = require('bluebird')
-const Emitter = require('../kite/emitter')
-const dnodeProtocol = require('dnode-protocol')
+import Promise from 'bluebird'
+import Emitter from '../kite/emitter'
+import dnodeProtocol from 'dnode-protocol'
 
 const toArray = Promise.promisify(require('stream-to-array'))
 const fs = Promise.promisifyAll(require('fs'))
-const { join: joinPath } = require('path')
-
-const KiteError = require('../kite/error')
-const Kontrol = require('../kontrol')
-
-const enableLogging = require('../kite/enableLogging')
-const { v4: createId } = require('uuid')
-
-const { getKontrolClaims } = require('../kite/claims')
-const { Defaults } = require('../constants')
+import { join as joinPath } from 'path'
+import KiteError from '../kite/error'
+import Kontrol from '../kontrol'
+import enableLogging from '../kite/enableLogging'
+import { v4 as createId } from 'uuid'
+import { getKontrolClaims } from '../kite/claims'
+import { Defaults } from '../constants'
 
 class KiteServer extends Emitter {
   constructor(options) {

--- a/src/server/index.test.js
+++ b/src/server/index.test.js
@@ -1,8 +1,8 @@
-const expect = require('expect')
-const Kite = require('../kite')
-const KiteServer = require('./')
-const SockJS = require('sockjs-client')
-const SockJsServer = require('./sockjs')
+import expect from 'expect'
+import Kite from '../kite'
+import KiteServer from './'
+import SockJS from 'sockjs-client'
+import SockJsServer from './sockjs'
 
 const logLevel = 0
 

--- a/src/server/sockjs/index.js
+++ b/src/server/sockjs/index.js
@@ -1,9 +1,8 @@
-const SockJS = require('sockjs')
-const http = require('http')
-
-const enableLogging = require('../../kite/enableLogging')
-const Emitter = require('../../kite/emitter')
-const Session = require('./session')
+import SockJS from 'sockjs'
+import http from 'http'
+import enableLogging from '../../kite/enableLogging'
+import Emitter from '../../kite/emitter'
+import Session from './session'
 
 class Server extends Emitter {
   constructor(options) {

--- a/src/server/sockjs/index.test.js
+++ b/src/server/sockjs/index.test.js
@@ -1,6 +1,6 @@
-const Kite = require('../../kite')
-const Server = require('./')
-const SockJS = require('sockjs-client')
+import Kite from '../../kite'
+import Server from './'
+import SockJS from 'sockjs-client'
 const logLevel = 0
 
 describe('SockJS Server with WebSocket', () => {

--- a/src/server/sockjs/session.js
+++ b/src/server/sockjs/session.js
@@ -1,4 +1,4 @@
-const Emitter = require('../../kite/emitter')
+import Emitter from '../../kite/emitter'
 
 export default class Session extends Emitter {
   constructor(connection) {

--- a/src/server/websocket/index.js
+++ b/src/server/websocket/index.js
@@ -1,6 +1,6 @@
-const { Server: WebSocketServer } = require('ws')
-const Emitter = require('../../kite/emitter')
-const Session = require('./session')
+import { Server as WebSocketServer } from 'ws'
+import Emitter from '../../kite/emitter'
+import Session from './session'
 
 class Server extends Emitter {
   constructor(options) {

--- a/src/server/websocket/index.test.js
+++ b/src/server/websocket/index.test.js
@@ -1,5 +1,5 @@
-const Kite = require('../../kite')
-const Server = require('./')
+import Kite from '../../kite'
+import Server from './'
 
 const logLevel = 0
 

--- a/src/server/websocket/session.js
+++ b/src/server/websocket/session.js
@@ -1,4 +1,4 @@
-const Emitter = require('../../kite/emitter')
+import Emitter from '../../kite/emitter'
 
 export default class Session extends Emitter {
   constructor(connection) {


### PR DESCRIPTION
@gokmen already fixed the exports, this pr fixes the `require`s. Also removes an `eslint` rule which conflicts with `prettier` rules.