### PR TITLE
Add more tests & extract functionality to other classes / functions

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -21,6 +21,7 @@ export const KnownEvents = [
   'warn',
   'info',
   'open',
+  'close',
   'debug',
 ]
 

--- a/src/constants.test.js
+++ b/src/constants.test.js
@@ -19,6 +19,7 @@ describe('constants', () =>
       'warn',
       'info',
       'open',
+      'close',
       'debug',
     ]
 

--- a/src/kite/KiteInfo.js
+++ b/src/kite/KiteInfo.js
@@ -1,0 +1,13 @@
+import { Defaults } from '../constants'
+
+export default class KiteInfo {
+  constructor(options = {}) {
+    this.id = options.id
+    this.username = options.username || Defaults.KiteInfo.username
+    this.environment = options.environment || Defaults.KiteInfo.environment
+    this.name = options.name || Defaults.KiteInfo.name
+    this.version = options.version || Defaults.KiteInfo.version
+    this.region = options.region || Defaults.KiteInfo.region
+    this.hostname = options.hostname || Defaults.KiteInfo.hostname
+  }
+}

--- a/src/kite/Logger.js
+++ b/src/kite/Logger.js
@@ -1,0 +1,54 @@
+import { DebugLevel } from '../constants'
+
+const defaults = {
+  error: (...args) => console.error(...args),
+  warn: (...args) => console.warn(...args),
+  info: (...args) => console.info(...args),
+}
+
+export default class Logger {
+  constructor(options = {}) {
+    const {
+      name,
+      level = DebugLevel.INFO,
+      error = defaults.error,
+      warn = defaults.warn,
+      info = defaults.info,
+    } = options
+
+    this.name = name
+    this.level = level
+    this.loggers = { error, warn, info }
+  }
+
+  logMessage(category, loggerType, ...args) {
+    if (DebugLevel[category] <= this.level) {
+      const fn = this.loggers
+      this.loggers[loggerType](`[${this.name}]`, category, ...args)
+    }
+  }
+
+  critical(...args) {
+    this.logMessage('CRITICAL', 'error', ...args)
+  }
+
+  error(...args) {
+    this.logMessage('ERROR', 'error', ...args)
+  }
+
+  warning(...args) {
+    this.logMessage('WARNING', 'warn', ...args)
+  }
+
+  notice(...args) {
+    this.logMessage('NOTICE', 'info', ...args)
+  }
+
+  info(...args) {
+    this.logMessage('INFO', 'info', ...args)
+  }
+
+  debug(...args) {
+    this.logMessage('DEBUG', 'info', ...args)
+  }
+}

--- a/src/kite/Logger.test.js
+++ b/src/kite/Logger.test.js
@@ -1,0 +1,35 @@
+import expect from 'expect'
+import Logger from './Logger'
+import { DebugLevel } from '../constants'
+
+describe('Logger', () => {
+  it('works', () => {
+    const logs = {
+      error: [],
+      warn: [],
+      info: [],
+    }
+
+    const logger = new Logger({
+      name: 'foobar',
+      level: DebugLevel.DEBUG,
+      error: (...args) => logs.error.push(args),
+      warn: (...args) => logs.warn.push(args),
+      info: (...args) => logs.info.push(args),
+    })
+
+    logger.critical('one')
+    logger.error('two')
+    logger.warning('three')
+    logger.notice('four')
+    logger.info('five')
+    logger.debug('six')
+
+    expect(logs.error[0]).toEqual(['[foobar]', 'CRITICAL', 'one'])
+    expect(logs.error[1]).toEqual(['[foobar]', 'ERROR', 'two'])
+    expect(logs.warn[0]).toEqual(['[foobar]', 'WARNING', 'three'])
+    expect(logs.info[0]).toEqual(['[foobar]', 'NOTICE', 'four'])
+    expect(logs.info[1]).toEqual(['[foobar]', 'INFO', 'five'])
+    expect(logs.info[2]).toEqual(['[foobar]', 'DEBUG', 'six'])
+  })
+})

--- a/src/kite/backoff.js
+++ b/src/kite/backoff.js
@@ -1,36 +1,31 @@
 import Timeout from './timeout'
 import { Backoff, Event } from '../constants'
 
-export default function(options = {}) {
+export default function backoff(options = {}) {
   const { backoff = {} } = options
   let totalReconnectAttempts = 0
-  const initalDelayMs = backoff.initialDelayMs != null
-    ? backoff.initialDelayMs
-    : Backoff.INITIAL_DELAY
-  const multiplyFactor = backoff.multiplyFactor != null
-    ? backoff.multiplyFactor
-    : Backoff.MULTIPLY_FACTOR
-  const maxDelayMs = backoff.maxDelayMs != null
-    ? backoff.maxDelayMs
-    : Backoff.MAX_DELAY
-  const maxReconnectAttempts = backoff.maxReconnectAttempts != null
-    ? backoff.maxReconnectAttempts
-    : Backoff.MAX_RECONNECT_ATTEMPTS
+
+  const {
+    initialDelayMs = Backoff.INITIAL_DELAY,
+    multiplyFactor = Backoff.MULTIPLY_FACTOR,
+    maxDelayMs = Backoff.MAX_DELAY,
+    maxReconnectAttempts = Backoff.MAX_RECONNECT_ATTEMPTS,
+  } = backoff
 
   this.clearBackoffTimeout = () => (totalReconnectAttempts = 0)
 
   this.clearBackoffHandle = function() {
     if (this.backoffHandle != null) {
       this.backoffHandle.clear()
-      return (this.backoffHandle = null)
+      this.backoffHandle = null
     }
   }
 
-  return (this.setBackoffTimeout = fn => {
+  this.setBackoffTimeout = fn => {
     this.clearBackoffHandle()
     if (totalReconnectAttempts < maxReconnectAttempts) {
       const timeout = Math.min(
-        initalDelayMs * Math.pow(multiplyFactor, totalReconnectAttempts),
+        initialDelayMs * Math.pow(multiplyFactor, totalReconnectAttempts),
         maxDelayMs
       )
       this.backoffHandle = new Timeout(fn, timeout)
@@ -38,5 +33,5 @@ export default function(options = {}) {
     } else {
       return this.emit(Event.backOffFailed)
     }
-  })
+  }
 }

--- a/src/kite/backoff.test.js
+++ b/src/kite/backoff.test.js
@@ -1,0 +1,27 @@
+import expect from 'expect'
+import backoff from './backoff'
+
+describe('backoff', () => {
+  // ideally this is a kite
+  class Thing {}
+  Thing.prototype.initBackoff = backoff
+
+  it('works with being attached to a prototype', () => {
+    // method names to be attached
+    const methods = [
+      'clearBackoffTimeout',
+      'clearBackoffHandle',
+      'setBackoffTimeout',
+    ]
+
+    const thing = new Thing()
+
+    methods.forEach(method => expect(thing[method]).toNotExist())
+
+    thing.initBackoff()
+
+    methods.forEach(method =>
+      expect(thing[method]).toExist(`${method} does not exist`)
+    )
+  })
+})

--- a/src/kite/base.js
+++ b/src/kite/base.js
@@ -1,16 +1,15 @@
-import dnode from 'dnode-protocol'
 import WebSocket from 'ws'
 import atob from 'atob'
 import uuid from 'uuid'
 import Emitter from './emitter'
 import now from './now'
 import backoff from './backoff'
-import wrap from './wrap'
 import handleIncomingMessage from './handleIncomingMessage'
 import enableLogging from './enableLogging'
 import Timeout from './timeout'
 import KiteError from './error'
 import MessageScrubber from './messagescrubber'
+import createProto from './createProto'
 import KiteInfo from './KiteInfo'
 import { Event, AuthType, Defaults, TimerHandles, State } from '../constants'
 
@@ -32,11 +31,7 @@ class Kite extends Emitter {
     super()
 
     this.id = uuid.v4()
-    this.options = Object.assign(
-      {},
-      Kite.defaultOptions,
-      options
-    )
+    this.options = Object.assign({}, Kite.defaultOptions, options)
 
     if (this.options.url && this.options.prefix) {
       this.options.url += this.options.prefix
@@ -49,7 +44,11 @@ class Kite extends Emitter {
 
     this.readyState = State.NOTREADY
 
-    this.proto = dnode(wrap.call(this, this.options.api))
+    this.proto = createProto({
+      kite: this,
+      api: this.options.api,
+    })
+
     this.messageScrubber = new MessageScrubber({ kite: this })
 
     this.proto.on(Event.request, req => {

--- a/src/kite/base.js
+++ b/src/kite/base.js
@@ -11,6 +11,7 @@ import enableLogging from './enableLogging'
 import Timeout from './timeout'
 import KiteError from './error'
 import MessageScrubber from './messagescrubber'
+import KiteInfo from './KiteInfo'
 import { Event, AuthType, Defaults, TimerHandles, State } from '../constants'
 
 class Kite extends Emitter {
@@ -162,15 +163,15 @@ class Kite extends Emitter {
       ? params[0].kiteName
       : undefined
 
-    return {
+    return new KiteInfo({
       id: this.id,
-      username: username || Defaults.KiteInfo.username,
-      environment: environment || Defaults.KiteInfo.environment,
-      name: name || Defaults.KiteInfo.name,
-      version: version || Defaults.KiteInfo.version,
-      region: region || Defaults.KiteInfo.region,
-      hostname: hostname || Defaults.KiteInfo.hostname,
-    }
+      username,
+      environment,
+      name,
+      version,
+      region,
+      hostname,
+    })
   }
 
   tell(method, params, callback) {

--- a/src/kite/base.js
+++ b/src/kite/base.js
@@ -110,13 +110,17 @@ class Kite extends Emitter {
     this.emit(Event.info, `Trying to connect to ${url}`)
   }
 
-  disconnect(reconnect = false) {
+  cleanTimerHandles() {
     for (let handle of TimerHandles) {
       if (this[handle] != null) {
         this[handle].clear()
         this[handle] = null
       }
     }
+  }
+
+  disconnect(reconnect = false) {
+    this.cleanTimerHandles()
     this.options.autoReconnect = !!reconnect
     if (this.transport != null) {
       this.transport.close()

--- a/src/kite/base.js
+++ b/src/kite/base.js
@@ -52,7 +52,7 @@ class Kite extends Emitter {
     this.messageScrubber = new MessageScrubber({ kite: this })
 
     this.proto.on(Event.request, req => {
-      this.ready(() => this.ws.send(JSON.stringify(req)))
+      this.ready(() => this.transport.send(JSON.stringify(req)))
       this.emit(Event.debug, 'Sending: ', JSON.stringify(req))
     })
 
@@ -97,14 +97,16 @@ class Kite extends Emitter {
     const { url, transportClass: Konstructor, transportOptions } = this.options
 
     // websocket will whine if extra arguments are passed
-    this.ws = Konstructor === WebSocket
+    this.transport = Konstructor === WebSocket
       ? new Konstructor(url)
       : new Konstructor(url, null, transportOptions)
-    this.ws.addEventListener(Event.open, this.bound('onOpen'))
-    this.ws.addEventListener(Event.close, this.bound('onClose'))
-    this.ws.addEventListener(Event.message, this.bound('onMessage'))
-    this.ws.addEventListener(Event.error, this.bound('onError'))
-    this.ws.addEventListener(Event.info, info => this.emit(Event.info, info))
+    this.transport.addEventListener(Event.open, this.bound('onOpen'))
+    this.transport.addEventListener(Event.close, this.bound('onClose'))
+    this.transport.addEventListener(Event.message, this.bound('onMessage'))
+    this.transport.addEventListener(Event.error, this.bound('onError'))
+    this.transport.addEventListener(Event.info, info =>
+      this.emit(Event.info, info)
+    )
     this.emit(Event.info, `Trying to connect to ${url}`)
   }
 
@@ -116,8 +118,8 @@ class Kite extends Emitter {
       }
     }
     this.options.autoReconnect = !!reconnect
-    if (this.ws != null) {
-      this.ws.close()
+    if (this.transport != null) {
+      this.transport.close()
     }
     this.emit(Event.notice, `Disconnecting from ${this.options.url}`)
   }

--- a/src/kite/base.test.js
+++ b/src/kite/base.test.js
@@ -21,7 +21,14 @@ describe('Kite', () => {
     it('requires a valid url', () => {
       expect(() => new Kite({})).toThrow(/"url" must be a string/)
       expect(() => new Kite({ url: 'foo' })).toThrow(/invalid url/)
-      expect(() => new Kite({ url: 'http://localhost' })).toNotThrow()
+      expect(
+        () =>
+          new Kite({
+            url: 'http://localhost',
+            autoConnect: false,
+            autoReconnect: false,
+          })
+      ).toNotThrow()
     })
 
     it('accepts a prefix', () => {

--- a/src/kite/base.test.js
+++ b/src/kite/base.test.js
@@ -77,14 +77,16 @@ describe('Kite', () => {
 
   describe('getKiteInfo', () =>
     it('should return default kite info if no option provided', () => {
-      let kite = new Kite({
+      const kite = new Kite({
         url: 'ws://localhost',
         autoConnect: false,
       })
       expect(kite).toExist()
 
-      let kiteInfo = kite.getKiteInfo()
-      delete kiteInfo.id // new id generated each time
-      expect(kiteInfo).toEqual(Defaults.KiteInfo)
+      const kiteInfo = kite.getKiteInfo()
+      expect(kiteInfo['environment']).toBe('browser-environment')
+      expect(kiteInfo['name']).toBe('browser-kite')
+      expect(kiteInfo['region']).toBe('browser-region')
+      expect(kiteInfo['username']).toBe('anonymous')
     }))
 })

--- a/src/kite/createProto.js
+++ b/src/kite/createProto.js
@@ -1,0 +1,6 @@
+import dnode from 'dnode-protocol'
+import wrap from './wrap'
+
+export default function createProto({ kite, api }) {
+  return dnode(wrap.call(kite, api))
+}

--- a/src/kite/wrap.js
+++ b/src/kite/wrap.js
@@ -1,6 +1,6 @@
 import Interval from './interval'
 
-export default function(userlandApi = {}) {
+export default function wrap(userlandApi = {}) {
   const api = ['error', 'info', 'log', 'warn'].reduce((api, method) => {
     api[method] = console[method].bind(console)
     return api

--- a/src/server/index.test.js
+++ b/src/server/index.test.js
@@ -3,6 +3,7 @@ import Kite from '../kite'
 import KiteServer from './'
 import SockJS from 'sockjs-client'
 import SockJsServer from './sockjs'
+import { Event, State } from '../constants'
 
 const logLevel = 0
 
@@ -44,7 +45,7 @@ describe('KiteServer with SockJS', () => {
 describe('KiteServer with WebSocket', () => {
   it('should be able to accept kite connections', done => {
     const kite = new Kite({
-      url: 'http://0.0.0.0:7780',
+      url: 'ws://0.0.0.0:7780',
       autoReconnect: false,
       autoConnect: false,
       logLevel,
@@ -73,3 +74,77 @@ describe('KiteServer with WebSocket', () => {
     kite.connect()
   })
 })
+
+describe('kite operations', () => {
+  // since we need a server to be able to test connection related methods of
+  // kite we need to do these here.
+  // TODO: export these tests into a more appropriate place.
+  //
+  describe('kite.disconnect()', () => {
+    it('should set readyState to closed', done => {
+      withServer((kite, server) => {
+        kite.ws.addEventListener(Event.close, () => {
+          process.nextTick(() => {
+            expect(kite.readyState).toBe(State.CLOSED)
+            server.close()
+            done()
+          })
+        })
+
+        kite.disconnect()
+      })
+    })
+
+    it('should try to reconnect when reconnect arg is true', done => {
+      const kite = new Kite({
+        url: 'ws://0.0.0.0:7780',
+        autoReconnect: true, // make sure autoReconnect is true
+        autoConnect: false,
+        logLevel,
+      })
+
+      withServer({ kite }, (kite, server) => {
+        kite.once('open', () => {
+          // if autoReconnect is working, this callbacck should be called again.
+          kite.disconnect()
+          server.close()
+          done()
+        })
+
+        // tell disconnect to retry again by passing `true` as arg.
+        kite.disconnect(true)
+      })
+    })
+  })
+})
+
+const withServer = (options, callback) => {
+  if (typeof options === 'function') {
+    callback = options
+    options = {}
+  }
+
+  const kite =
+    options.kite ||
+    new Kite({
+      url: 'ws://0.0.0.0:7780',
+      autoReconnect: false,
+      autoConnect: false,
+      logLevel,
+    })
+
+  const server =
+    options.server ||
+    new KiteServer({
+      name: 'server',
+      auth: false,
+      logLevel,
+    })
+
+  kite.once('open', () => {
+    callback(kite, server)
+  })
+
+  server.listen(7780)
+  kite.connect()
+}

--- a/src/server/index.test.js
+++ b/src/server/index.test.js
@@ -83,7 +83,7 @@ describe('kite operations', () => {
   describe('kite.disconnect()', () => {
     it('should set readyState to closed', done => {
       withServer((kite, server) => {
-        kite.ws.addEventListener(Event.close, () => {
+        kite.transport.addEventListener(Event.close, () => {
           process.nextTick(() => {
             expect(kite.readyState).toBe(State.CLOSED)
             server.close()

--- a/src/server/sockjs/index.js
+++ b/src/server/sockjs/index.js
@@ -20,7 +20,7 @@ class Server extends Emitter {
 
     const sockjsOptions = {
       log: (level, message) => {
-        const fn = this.logger[level]
+        const fn = this.logger[level].bind(this.logger)
         if (fn) {
           fn(message)
         }

--- a/src/server/sockjs/index.js
+++ b/src/server/sockjs/index.js
@@ -7,7 +7,10 @@ import Session from './session'
 class Server extends Emitter {
   constructor(options = {}) {
     super()
+
+    this.options = options
     this.options.hostname = this.options.hostname || '0.0.0.0'
+
     if (!this.options.port) throw new Error('port is required!')
 
     this.logger = new Logger({

--- a/src/server/sockjs/index.js
+++ b/src/server/sockjs/index.js
@@ -1,22 +1,26 @@
 import SockJS from 'sockjs'
 import http from 'http'
-import enableLogging from '../../kite/enableLogging'
+import Logger from '../../kite/Logger'
 import Emitter from '../../kite/emitter'
 import Session from './session'
 
 class Server extends Emitter {
-  constructor(options) {
+  constructor(options = {}) {
     super()
-
-    this.options = options ? options : {}
     this.options.hostname = this.options.hostname || '0.0.0.0'
     if (!this.options.port) throw new Error('port is required!')
 
-    enableLogging(options.name, this, options.logLevel)
+    this.logger = new Logger({
+      name: options.name,
+      level: options.logLevel,
+    })
 
     const sockjsOptions = {
       log: (level, message) => {
-        this.emit(level, message)
+        const fn = this.logger[level]
+        if (fn) {
+          fn(message)
+        }
       },
     }
 
@@ -24,13 +28,13 @@ class Server extends Emitter {
     this.server = http.createServer()
 
     this.sockjs.on('connection', connection => {
-      this.emit('debug', 'a new connection', connection)
+      this.logger.debug('a new connection', connection)
       this.emit('connection', new Session(connection))
     })
 
     this.sockjs.installHandlers(this.server, { prefix: options.prefix || '' })
 
-    this.emit('debug', 'starting to listen on server', options)
+    this.logger.debug('starting to listen on server', options)
     this.server.listen(options.port, options.hostname)
   }
 


### PR DESCRIPTION
- [ ] write tests for covering `disconnect` & `close` events
- [ ] write tests for covering `autoReconnect` behavior
- [ ] move backoff functionality to its own class
- [ ] abstract out protocol initialization step
- [x] abstract out kite info struct to `KiteInfo` class
- [ ] clean up interactions between `protocol (proto)` and `transport (ws)` on connection events.

fixes #43 