### PR TITLE
Accept connection option to enable Kites through an existing connection

### DIFF
--- a/src/kite/base.js
+++ b/src/kite/base.js
@@ -165,11 +165,14 @@ class BaseKite extends Emitter {
 
   onOpen() {
     this.readyState = State.READY
-    // FIXME: the following is ridiculous.
+
     this.emit(Event.notice, `Connected to Kite: ${this.options.url}`)
+
+    // FIXME: the following is ridiculous.
     if (typeof this.clearBackoffTimeout === 'function') {
       this.clearBackoffTimeout()
     }
+
     this.emit(Event.open)
   }
 

--- a/src/kite/base.js
+++ b/src/kite/base.js
@@ -140,13 +140,17 @@ class BaseKite extends Emitter {
     connection.addEventListener(Event.info, info => this.emit(Event.info, info))
   }
 
-  disconnect(reconnect = false) {
+  cleanTimerHandlers() {
     for (let handle of TimerHandles) {
       if (this[handle] != null) {
         this[handle].clear()
         this[handle] = null
       }
     }
+  }
+
+  disconnect(reconnect = false) {
+    this.cleanTimerHandlers()
     this.options.autoReconnect = !!reconnect
     if (this.ws != null) {
       this.ws.close()

--- a/src/kite/base.js
+++ b/src/kite/base.js
@@ -182,7 +182,7 @@ class BaseKite extends Emitter {
 
     let dcInfo = `${this.options.url}: disconnected`
     // enable below to autoReconnect when the socket has been closed
-    if (this.options.autoReconnect) {
+    if (this.canReconnect()) {
       process.nextTick(() => this.setBackoffTimeout(this.bound('connect')))
       dcInfo += ', trying to reconnect...'
     }

--- a/src/kite/base.js
+++ b/src/kite/base.js
@@ -115,6 +115,11 @@ class BaseKite extends Emitter {
     return ![State.CONNECTING, State.READY].includes(this.readyState)
   }
 
+  canReconnect() {
+    // we don't want to reconnect if a connection is passed already.
+    return !this.options.connection && this.options.autoReconnect
+  }
+
   connect() {
     if (!this.canConnect()) {
       return

--- a/src/kite/base.js
+++ b/src/kite/base.js
@@ -111,12 +111,18 @@ class BaseKite extends Emitter {
     this.ws = Konstructor === WebSocket
       ? new Konstructor(url)
       : new Konstructor(url, null, transportOptions)
-    this.ws.addEventListener(Event.open, this.bound('onOpen'))
-    this.ws.addEventListener(Event.close, this.bound('onClose'))
-    this.ws.addEventListener(Event.message, this.bound('onMessage'))
-    this.ws.addEventListener(Event.error, this.bound('onError'))
-    this.ws.addEventListener(Event.info, info => this.emit(Event.info, info))
+
+    this.addConnectionHandlers(this.ws)
+
     this.emit(Event.info, `Trying to connect to ${url}`)
+  }
+
+  addConnectionHandlers(connection) {
+    connection.addEventListener(Event.open, this.bound('onOpen'))
+    connection.addEventListener(Event.close, this.bound('onClose'))
+    connection.addEventListener(Event.message, this.bound('onMessage'))
+    connection.addEventListener(Event.error, this.bound('onError'))
+    connection.addEventListener(Event.info, info => this.emit(Event.info, info))
   }
 
   disconnect(reconnect = false) {

--- a/src/server/index.test.js
+++ b/src/server/index.test.js
@@ -147,7 +147,7 @@ describe('KiteServer connection', () => {
       const math = new KiteServer({
         name: 'math',
         auth: false,
-        serverClass: KiteServer.transport.SockJs,
+        serverClass: KiteServer.transport.SockJS,
         logLevel,
         api: {
           square: function(x, callback) {


### PR DESCRIPTION
Instead of using a `transport` option mentioned in #51 i decided to use a `connection` option as it fits better IMO.