### PR TITLE
Replace custom modifications with proper dnode-protocol calls

### DIFF
--- a/src/kite/base.js
+++ b/src/kite/base.js
@@ -207,8 +207,8 @@ class BaseKite extends Emitter {
   }
 
   onError(err) {
-    this.emit(Event.error, 'Websocket error!')
-    this.logger.error('WebSocket error!')
+    this.emit(Event.error, 'Websocket error!', err)
+    this.logger.error('WebSocket error!', err)
   }
 
   getKiteInfo() {

--- a/src/kite/handleIncomingMessage.js
+++ b/src/kite/handleIncomingMessage.js
@@ -18,7 +18,7 @@ export default function handleIncomingMessage(proto, message) {
   }
 
   if (!isKiteReq(req)) {
-    this.emit(Event.debug, 'Handling a normal dnode message')
+    this.emit(Event.debug, 'Handling a normal dnode message', req)
     return proto.handle(req)
   }
 

--- a/src/kite/handleIncomingMessage.js
+++ b/src/kite/handleIncomingMessage.js
@@ -22,16 +22,10 @@ export default function handleIncomingMessage(proto, message) {
     return proto.handle(req)
   }
 
-  const { links, method, callbacks } = req
-  const {
-    withArgs = [],
-    authentication: auth,
-    responseCallback,
-  } = parseKiteReq(req)
+  const auth = getRequestAuth(req)
+  const responseCallback = getRequestCallback(req)
 
-  this.emit(Event.debug, 'Authenticating request')
-
-  return handleAuth(this, method, auth, this.key)
+  return handleAuth(this, req.method, auth, this.key)
     .then(token => {
       this.emit(Event.debug, 'Authentication passed')
 
@@ -41,18 +35,17 @@ export default function handleIncomingMessage(proto, message) {
       this.currentToken = token
 
       try {
-        proto.handle(
-          toProtoReq({
-            method,
-            withArgs,
-            responseCallback,
-            links,
-            callbacks,
-          })
-        )
+        proto.handle(req)
       } catch (err) {
         this.emit(Event.debug, 'Error processing request', err)
-        proto.handle(getTraceReq({ err, responseCallback, links, callbacks }))
+        proto.handle(
+          getTraceReq({
+            err,
+            responseCallback,
+            links: req.links,
+            callbacks: req.callbacks,
+          })
+        )
       }
 
       this.currentToken = null
@@ -62,66 +55,32 @@ export default function handleIncomingMessage(proto, message) {
       this.emit(Event.debug, 'Authentication failed', err)
 
       return proto.handle(
-        getTraceReq({ err, responseCallback, links, callbacks })
+        getTraceReq({
+          err,
+          responseCallback,
+          links: req.links,
+          callbacks: req.callbacks,
+        })
       )
     })
 }
 
 const isKiteReq = req =>
   req.arguments.length &&
-  req.arguments[0] &&
-  req.arguments[0].responseCallback &&
-  req.arguments[0].withArgs
+  req.arguments[req.arguments.length - 1] &&
+  req.arguments[req.arguments.length - 1].kite
 
 const getTraceReq = o => {
   return {
     method: 'kite.echo',
     arguments: [o.err, o.responseCallback],
     links: o.links,
-    callbacks: mungeCallbacks(o.callbacks, 1),
+    callbacks: o.callbacks,
   }
 }
 
-const parseKiteReq = req => req.arguments[0]
+const getRequestAuth = req =>
+  req.arguments.length && req.arguments[req.arguments.length - 1].authentication
 
-const isResponseCallback = callback =>
-  Array.isArray(callback) && callback.join('.') === '0.responseCallback'
-
-const mungeCallbacks = (callbacks, n) => {
-  // FIXME: this is an ugly hack; there must be a better way to implement it:
-
-  for (let key of Object.keys(callbacks || {})) {
-    const callback = callbacks[key]
-    if (isResponseCallback(callback)) {
-      callbacks[key] = [n]
-    }
-    if (callback[1] === 'withArgs') {
-      // since we're rewriting the protocol for the withArgs case,
-      // we need to remove everything up to withArgs
-      callbacks[key] = callback.slice(2)
-    }
-  }
-
-  return callbacks
-}
-
-const toProtoReq = ({
-  method,
-  withArgs,
-  responseCallback,
-  links,
-  callbacks,
-}) => {
-  if (!Array.isArray(withArgs)) {
-    withArgs = [withArgs]
-  }
-
-  mungeCallbacks(callbacks, withArgs.length)
-
-  return {
-    method,
-    arguments: [...Array.from(withArgs), responseCallback],
-    links,
-    callbacks,
-  }
-}
+const getRequestCallback = req =>
+  req.arguments.length && req.arguments[req.arguments.length - 2]

--- a/src/kite/messagescrubber.js
+++ b/src/kite/messagescrubber.js
@@ -18,11 +18,10 @@ export default class MessageScrubber {
     params = Array.isArray(params) ? params : [params]
     return [
       ...params,
-      function responseCallback(response) {
-        const { error: rawErr, result } = response || {}
+      function responseCallback(rawErr, response) {
         const err = rawErr != null ? KiteError.makeProperError(rawErr) : null
 
-        return callback(err, result)
+        return callback(err, response)
       },
       {
         kite: this.kite.getKiteInfo(),

--- a/src/kite/messagescrubber.test.js
+++ b/src/kite/messagescrubber.test.js
@@ -25,16 +25,23 @@ describe('kite/messagescrubber', () => {
 
       const result = scrubber.wrapMessage(params, callback)
 
-      expect(result.kite).toInclude(Defaults.KiteInfo)
-      expect(result.withArgs).toEqual(params)
+      // ...params, callback, kiteInfo
+      expect(result.length).toBe(6)
+
+      expect(result[0]).toEqual(1)
+      expect(result[1]).toEqual(2)
+      expect(result[2]).toEqual(3)
+      expect(result[3]).toEqual(4)
+
+      expect(result[5].kite).toInclude(Defaults.KiteInfo)
 
       // test the returned responseCallback works correctly
       expect(called).toBe(false)
-      result.responseCallback({})
+      result[4]({})
       expect(called).toBe(true)
 
       expect.spyOn(KiteError, 'makeProperError')
-      result.responseCallback({ error: 'raw error' })
+      result[4]({ error: 'raw error' })
       expect(KiteError.makeProperError).toHaveBeenCalledWith('raw error')
     })
 
@@ -44,7 +51,7 @@ describe('kite/messagescrubber', () => {
 
       const result = scrubber.wrapMessage([1, 2, 3], () => {})
 
-      expect(result.authentication).toEqual({ foo: 'bar' })
+      expect(result[4].authentication).toEqual({ foo: 'bar' })
     })
   })
 

--- a/src/kite/messagescrubber.test.js
+++ b/src/kite/messagescrubber.test.js
@@ -41,8 +41,11 @@ describe('kite/messagescrubber', () => {
       expect(called).toBe(true)
 
       expect.spyOn(KiteError, 'makeProperError')
-      result[4]({ error: 'raw error' })
-      expect(KiteError.makeProperError).toHaveBeenCalledWith('raw error')
+
+      const err = { message: 'raw error' }
+
+      result[4](err)
+      expect(KiteError.makeProperError).toHaveBeenCalledWith(err)
     })
 
     it('wraps kite auth option as authentication param', () => {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -205,9 +205,9 @@ class KiteServer extends Emitter {
     ws.on('message', rawData => {
       const message = parse(rawData)
       if (this.api.hasMethod(message.method)) {
-        this.handleMessage.call(this, proto, message, ws.kite)
+        this.handleMessage(proto, message, ws.kite)
       } else {
-        if (message.arguments.length == 2) {
+        if (message.arguments.length === 2) {
           let [error, result] = message.arguments
           message.arguments = [{ error, result }]
         }

--- a/src/server/index.test.js
+++ b/src/server/index.test.js
@@ -247,3 +247,39 @@ describe('KiteServer to Remote Kite connection', () => {
     kite.connect()
   })
 })
+
+describe('error handling', () => {
+  it('should handle errors properly', done => {
+    const errorServer = new KiteServer({
+      name: 'error-server',
+      auth: false,
+      logLevel,
+      api: {
+        makeError: function(callback) {
+          callback(new Error('awesome error'))
+        },
+      },
+    })
+
+    const kite = new Kite({
+      url: 'http://0.0.0.0:7780',
+      autoReconnect: false,
+      autoConnect: false,
+      logLevel,
+    })
+
+    kite.on('open', () => {
+      kite
+        .tell('makeError')
+        .catch(err => expect(err.message).toBe('awesome error'))
+        .finally(() => {
+          kite.disconnect()
+          errorServer.close()
+          done()
+        })
+    })
+
+    errorServer.listen(7780)
+    kite.connect()
+  })
+})


### PR DESCRIPTION
This PR implements the initial phase of #63
> Refactor the current implementation without introducing new classes/types and
make sure all the current tests are passing.

Since this introduces breaking changes on how we handle 