### PR TITLE
Introduce new Kite components

### DIFF
--- a/src/KiteApi.js
+++ b/src/KiteApi.js
@@ -1,3 +1,4 @@
+import dnode from 'dnode-protocol'
 import { DefaultApi } from './constants'
 
 const isFunction = thing => typeof thing === 'function'
@@ -7,6 +8,11 @@ export default class KiteApi {
     this.auth = auth
     this.methods = this.setMethods(Object.assign({}, DefaultApi, methods))
     this.methodKeys = Object.keys(this.methods)
+    this.proto = this.makeProto()
+  }
+
+  makeProto() {
+    return dnode(this.methods)
   }
 
   hasMethod(method) {

--- a/src/KiteApi.js
+++ b/src/KiteApi.js
@@ -1,12 +1,11 @@
 import dnode from 'dnode-protocol'
-import { DefaultApi } from './constants'
 
 const isFunction = thing => typeof thing === 'function'
 
 export default class KiteApi {
   constructor({ auth, methods }) {
     this.auth = auth
-    this.methods = this.setMethods(Object.assign({}, DefaultApi, methods))
+    this.methods = this.setMethods(methods)
     this.methodKeys = Object.keys(this.methods)
     this.proto = this.makeProto()
   }
@@ -20,7 +19,7 @@ export default class KiteApi {
     return this.methodKeys.includes(method)
   }
 
-  setMethods(methods) {
+  setMethods(methods = {}) {
     return Object.keys(methods).reduce((acc, methodName) => {
       return Object.assign(acc, this.setMethod(methodName, methods[methodName]))
     }, {})

--- a/src/kite/base.js
+++ b/src/kite/base.js
@@ -1,4 +1,3 @@
-import dnode from 'dnode-protocol'
 import atob from 'atob'
 import uuid from 'uuid'
 import Emitter from './emitter'
@@ -70,14 +69,13 @@ class BaseKite extends Emitter {
       methods: wrap.call(this, this.options.api),
     })
 
-    this.proto = dnode(this.api.methods)
     this.messageScrubber = new MessageScrubber({
       info: this.getKiteInfo(),
       logger: this.logger,
-      proto: this.proto,
+      proto: this.api.proto,
     })
 
-    this.proto.on(Event.request, req => {
+    this.api.proto.on(Event.request, req => {
       const message = JSON.stringify(req)
       this.ready(() => this.ws.send(message))
       this.logger.debug('Sending:', message)
@@ -207,7 +205,7 @@ class BaseKite extends Emitter {
   }
 
   onMessage({ data }) {
-    handleIncomingMessage.call(this, this.proto, data)
+    handleIncomingMessage.call(this, this.api.proto, data)
   }
 
   onError(err) {
@@ -238,7 +236,7 @@ class BaseKite extends Emitter {
 
   tell(method, params, callback) {
     const scrubbed = this.messageScrubber.scrub(method, params, callback)
-    this.proto.emit(Event.request, scrubbed)
+    this.api.proto.emit(Event.request, scrubbed)
   }
 
   expireTokenOnExpiry() {

--- a/src/kite/base.js
+++ b/src/kite/base.js
@@ -71,7 +71,11 @@ class BaseKite extends Emitter {
     })
 
     this.proto = dnode(this.api.methods)
-    this.messageScrubber = new MessageScrubber({ kite: this })
+    this.messageScrubber = new MessageScrubber({
+      info: this.getKiteInfo(),
+      logger: this.logger,
+      proto: this.proto,
+    })
 
     this.proto.on(Event.request, req => {
       const message = JSON.stringify(req)

--- a/src/kite/messagescrubber.js
+++ b/src/kite/messagescrubber.js
@@ -29,7 +29,7 @@ export default class MessageScrubber {
   }
 
   scrub(method, params, callback) {
-    if (!callback && typeof params == 'function') {
+    if (!callback && typeof params === 'function') {
       callback = params
       params = []
     }

--- a/src/kite/messagescrubber.test.js
+++ b/src/kite/messagescrubber.test.js
@@ -1,3 +1,4 @@
+import dnode from 'dnode-protocol'
 import expect from 'expect'
 import Kite from './'
 import KiteError from './error'
@@ -7,10 +8,8 @@ import MessageScrubber from './messagescrubber'
 
 describe('kite/messagescrubber', () => {
   it('expects a kite to be passed', () => {
-    expect(() => new MessageScrubber()).toThrow(/invalid kite: undefined/)
-    expect(
-      () => new MessageScrubber({ kite: new Kite({ autoConnect: false }) })
-    ).toNotThrow()
+    expect(() => new MessageScrubber()).toThrow(/invalid kite info: undefined/)
+    expect(() => new MessageScrubber({ info: {} })).toNotThrow()
   })
 
   describe('wrapMessage', () => {
@@ -20,7 +19,10 @@ describe('kite/messagescrubber', () => {
 
       let callback = () => (called = true)
 
-      const scrubber = new MessageScrubber({ kite })
+      const scrubber = new MessageScrubber({
+        info: kite.getKiteInfo(),
+        logger: kite.logger,
+      })
       const params = [1, 2, 3, 4]
 
       const result = scrubber.wrapMessage(params, callback)
@@ -40,7 +42,11 @@ describe('kite/messagescrubber', () => {
 
     it('wraps kite auth option as authentication param', () => {
       const kite = new Kite({ autoConnect: false, auth: { foo: 'bar' } })
-      const scrubber = new MessageScrubber({ kite })
+      const scrubber = new MessageScrubber({
+        info: kite.getKiteInfo(),
+        auth: kite.options.auth,
+        logger: kite.logger,
+      })
 
       const result = scrubber.wrapMessage([1, 2, 3], () => {})
 
@@ -51,7 +57,13 @@ describe('kite/messagescrubber', () => {
   describe('scrub', () => {
     it('scrubs parameters to make it ready for rpc call', () => {
       const kite = new Kite({ autoConnect: false })
-      const scrubber = new MessageScrubber({ kite })
+
+      const scrubber = new MessageScrubber({
+        info: kite.getKiteInfo(),
+        auth: false,
+        logger: kite.logger,
+        proto: dnode({}),
+      })
 
       const result = scrubber.scrub('ping', [1, 2], () => {})
 

--- a/src/kontrol/getpath.js
+++ b/src/kontrol/getpath.js
@@ -1,4 +1,4 @@
-export function getPath(query) {
+export default function getPath(query) {
   const val = query.username
   const username = val != null ? val : ''
   const val1 = query.environment

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,5 +1,4 @@
 import Emitter from '../kite/emitter'
-import dnodeProtocol from 'dnode-protocol'
 
 import parse from 'try-json-parse'
 
@@ -105,7 +104,7 @@ class KiteServer extends Emitter {
   }
 
   onConnection(ws) {
-    const proto = dnodeProtocol(this.api.methods)
+    const proto = this.api.makeProto()
     proto.on('request', this.lazyBound('handleRequest', ws))
 
     const id = ws.getId()
@@ -135,7 +134,7 @@ class KiteServer extends Emitter {
           let [error, result] = message.arguments
           message.arguments = [{ error, result }]
         }
-        this.handleMessage.call(ws.kite, ws.kite.proto, message)
+        this.handleMessage.call(ws.kite, ws.kite.api.proto, message)
       }
     })
 


### PR DESCRIPTION
This is an initial attempt to move `proto` instance into `KiteApi` therefore create a way to abstract away which protocol is gonna be used, thus we can change the `dnode-protocol` with any other `rpc` implementation.